### PR TITLE
Update Retrieving the event detail api 

### DIFF
--- a/src/modules/events/dto/find-event.dto.ts
+++ b/src/modules/events/dto/find-event.dto.ts
@@ -1,5 +1,29 @@
-import { Event } from '../entities';
+import { Comment, Event } from '../entities';
 import { ApiProperty } from '@nestjs/swagger';
+
+class CommentDto {
+  @ApiProperty()
+  id: number;
+  @ApiProperty()
+  content: string;
+  @ApiProperty()
+  memberId: number;
+  @ApiProperty()
+  memberNickname: string;
+  @ApiProperty()
+  createdAt: Date;
+  @ApiProperty()
+  updatedAt: Date;
+
+  constructor(comment: Comment) {
+    this.id = comment.id;
+    this.content = comment.content;
+    this.memberId = comment.member.id;
+    this.memberNickname = comment.member.nickname;
+    this.createdAt = comment.createdAt;
+    this.updatedAt = comment.updatedAt;
+  }
+}
 
 export class FindEventDto {
   @ApiProperty()
@@ -11,20 +35,27 @@ export class FindEventDto {
   @ApiProperty()
   media?: string;
   @ApiProperty()
-  likes: number = 0;
+  likeCount: number = 0;
   @ApiProperty()
-  comments: number = 0;
+  commentCount: number = 0;
+  @ApiProperty({ type: [CommentDto] })
+  comments?: CommentDto[];
   @ApiProperty()
   createdAt!: Date;
 
   static of(event: Event): FindEventDto {
     const dto = new FindEventDto();
+    const commentDtos = (event.comments ?? []).map((comment) => {
+      return new CommentDto(comment);
+    });
+
     dto.id = event.id;
     dto.title = event.title;
     dto.content = event.content;
     dto.media = event.media;
-    dto.likes = event.likesCount;
-    dto.comments = event.commentsCount;
+    dto.likeCount = event.likesCount;
+    dto.commentCount = event.commentsCount;
+    dto.comments = commentDtos;
     dto.createdAt = event.createdAt;
     return dto;
   }

--- a/src/modules/events/entities/event.entity.ts
+++ b/src/modules/events/entities/event.entity.ts
@@ -4,9 +4,11 @@ import {
   Column,
   ManyToOne,
   JoinColumn,
+  OneToMany,
 } from 'typeorm';
 import { Member } from '../../members/entities';
 import { DefaultEntity } from '../../../common/default.entity';
+import { Comment } from './comment.entity';
 
 @Entity()
 export class Event extends DefaultEntity {
@@ -52,4 +54,7 @@ export class Event extends DefaultEntity {
 
   @Column({ type: 'int', default: 0 })
   commentsCount: number = 0;
+
+  @OneToMany(() => Comment, (comment) => comment.event, { onDelete: 'CASCADE' })
+  comments?: Comment[];
 }

--- a/src/modules/events/repository/events.repository.ts
+++ b/src/modules/events/repository/events.repository.ts
@@ -15,11 +15,12 @@ export class EventsRepository {
   }
 
   async findById(eventId: number): Promise<Event | null> {
-    return this.eventRepository.findOne({
-      where: {
-        id: eventId,
-      },
-    });
+    return this.eventRepository
+      .createQueryBuilder('event')
+      .leftJoinAndSelect('event.comments', 'comment')
+      .leftJoinAndSelect('comment.member', 'member')
+      .where('event.id=:eventId', { eventId })
+      .getOne();
   }
 
   async findNearby(

--- a/test/unit/events.service.spec.ts
+++ b/test/unit/events.service.spec.ts
@@ -105,7 +105,6 @@ describe('EventService', () => {
       jest
         .spyOn(naverService, 'getAddressFromCoordinate')
         .mockResolvedValue(region);
-      // jest.spyOn(s3Service, 'upload').mockResolvedValue(null);
 
       await eventService.create(request, memberId, media);
 


### PR DESCRIPTION
## #️⃣Related Issue
> #35 

## 📝Work Description
1. 이벤트를 조회할 때 댓글 목록도 함께 조회되도록 수정
2. 스웨거 return 수정

<img width="937" alt="image" src="https://github.com/user-attachments/assets/ad65bd4e-c1dc-40a2-8cc6-472405d55a7d">

<img width="782" alt="image" src="https://github.com/user-attachments/assets/a6243e01-bfd9-4bd9-82b2-0f42e3bc19a0">

