### PR TITLE
Fix get event api 

### DIFF
--- a/src/modules/events/dto/find-event.dto.ts
+++ b/src/modules/events/dto/find-event.dto.ts
@@ -11,6 +11,8 @@ class CommentDto {
   @ApiProperty()
   memberNickname: string;
   @ApiProperty()
+  memberProfile: string | null;
+  @ApiProperty()
   createdAt: Date;
   @ApiProperty()
   updatedAt: Date;
@@ -20,6 +22,7 @@ class CommentDto {
     this.content = comment.content;
     this.memberId = comment.member.id;
     this.memberNickname = comment.member.nickname;
+    this.memberProfile = comment.member.memberDetail?.profilePicture ?? null;
     this.createdAt = comment.createdAt;
     this.updatedAt = comment.updatedAt;
   }
@@ -28,6 +31,12 @@ class CommentDto {
 export class FindEventDto {
   @ApiProperty()
   id!: number;
+  @ApiProperty()
+  memberNickname!: string;
+  @ApiProperty()
+  memberProfile?: string;
+  @ApiProperty()
+  address!: string;
   @ApiProperty()
   title!: string;
   @ApiProperty()
@@ -50,8 +59,10 @@ export class FindEventDto {
     const commentDtos = (event.comments ?? []).map((comment) => {
       return new CommentDto(comment);
     });
-
     dto.id = event.id;
+    dto.memberNickname = event.member.nickname;
+    dto.memberProfile = event.member.memberDetail?.profilePicture;
+    dto.address = `${event.si} ${event.gu} ${event.dong}` as string;
     dto.title = event.title;
     dto.content = event.content;
     dto.media = event.media;

--- a/src/modules/events/dto/get-feeds.dto.ts
+++ b/src/modules/events/dto/get-feeds.dto.ts
@@ -1,19 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Event } from '../entities';
 
-export class GetFeedsDto {
-  constructor(
-    eventId: number,
-    title: string,
-    content?: string,
-    media?: string,
-  ) {
-    this.eventId = eventId;
-    this.title = title;
-    this.content = content;
-    this.media = media;
-  }
-
+class EventData {
   @ApiProperty()
   eventId!: number;
 
@@ -26,9 +14,31 @@ export class GetFeedsDto {
   @ApiProperty()
   media?: string;
 
-  static of(events: Event[]): GetFeedsDto[] {
-    return events.map((event) => {
-      return new GetFeedsDto(event.id, event.title, event.content, event.media);
+  constructor(
+    eventId: number,
+    title: string,
+    content?: string,
+    media?: string,
+  ) {
+    this.eventId = eventId;
+    this.title = title;
+    this.content = content;
+    this.media = media;
+  }
+}
+
+export class GetFeedsDto {
+  @ApiProperty({ type: [EventData] })
+  events: EventData[];
+
+  constructor(events: EventData[]) {
+    this.events = events;
+  }
+
+  static of(events: Event[]): GetFeedsDto {
+    const eventDatas = events.map((event) => {
+      return new EventData(event.id, event.title, event.content, event.media);
     });
+    return new GetFeedsDto(eventDatas);
   }
 }

--- a/src/modules/events/repository/events.repository.ts
+++ b/src/modules/events/repository/events.repository.ts
@@ -17,8 +17,11 @@ export class EventsRepository {
   async findById(eventId: number): Promise<Event | null> {
     return this.eventRepository
       .createQueryBuilder('event')
+      .leftJoinAndSelect('event.member', 'eventMember')
+      .leftJoinAndSelect('eventMember.memberDetail', 'eventMemberDetail')
       .leftJoinAndSelect('event.comments', 'comment')
-      .leftJoinAndSelect('comment.member', 'member')
+      .leftJoinAndSelect('comment.member', 'commentMember')
+      .leftJoinAndSelect('commentMember.memberDetail', 'commentMemberDetail')
       .where('event.id=:eventId', { eventId })
       .getOne();
   }

--- a/src/modules/events/service/events.service.ts
+++ b/src/modules/events/service/events.service.ts
@@ -87,7 +87,7 @@ export class EventsService {
     return FindNearbyAllDto.of(events, region);
   }
 
-  async getFeeds(): Promise<GetFeedsDto[]> {
+  async getFeeds(): Promise<GetFeedsDto> {
     const events = await this.eventsRepository.findEventsOrderByLikes();
     return GetFeedsDto.of(events);
   }


### PR DESCRIPTION
## #️⃣Related Issue
> #58

## 📝Work Description
1. 이벤트 조회 api 수정
- 작성자 닉네임, 프로필, 사건 발생 지역 반환
- 댓글 작성자 닉네임, 프로필 반환
<img width="448" alt="image" src="https://github.com/user-attachments/assets/b333f9f7-2e12-4e44-8236-0643196ae883">

2. Feed 조회 api 응답이 스웨거랑 불이칠하는 문제 해결
<img width="399" alt="image" src="https://github.com/user-attachments/assets/0be415ad-819b-4bcd-9131-8c885b0bc0f4">

3. 테스트 코드 수정
<img width="382" alt="image" src="https://github.com/user-attachments/assets/8a3f7a61-7e1e-434b-b1a5-58083755db9b">

