### PR TITLE
Fix create event api

### DIFF
--- a/src/modules/events/dto/create-event.dto.ts
+++ b/src/modules/events/dto/create-event.dto.ts
@@ -1,15 +1,16 @@
 import {
+  IsEnum,
+  IsLatitude,
+  IsLongitude,
   IsNotEmpty,
   IsNumber,
   MaxLength,
-  IsLatitude,
-  IsLongitude,
 } from 'class-validator';
 import { EventBuilder } from '../entities/builder/event.builder';
 import { Event } from '../entities';
-import { EventType } from '../enum/event-type.enum';
-import { Region } from 'src/external/naver/dto/region.dto';
 import { Member } from 'src/modules/members/entities';
+import { DisasterLevel } from '../entities/enum/disaster-level.enum';
+import { EventType } from '../entities/enum/event-type.enum';
 
 export class CreateEventDto {
   @IsNotEmpty({
@@ -49,16 +50,25 @@ export class CreateEventDto {
   })
   longitude!: number;
 
-  toEvent(region: Region, member: Member, mediaUrl?: string): Event {
+  @IsNotEmpty({
+    message: '주소는 필수 입력 항목입니다.',
+  })
+  address!: string;
+
+  @IsEnum(EventType, {
+    message: '유효한 이벤트 타입을 입력해 주세요.',
+  })
+  type!: EventType;
+
+  toEvent(member: Member, mediaUrl?: string): Event {
     return new EventBuilder()
       .title(this.title)
       .content(this.content)
       .latitude(this.latitude)
       .longitude(this.longitude)
-      .type(EventType.SECONDARY)
-      .si(region.si)
-      .gu(region.gu)
-      .dong(region.dong)
+      .disasterLevel(DisasterLevel.SECONDARY)
+      .address(this.address)
+      .type(this.type)
       .member(member)
       .media(mediaUrl)
       .build();

--- a/src/modules/events/dto/find-event.dto.ts
+++ b/src/modules/events/dto/find-event.dto.ts
@@ -62,7 +62,7 @@ export class FindEventDto {
     dto.id = event.id;
     dto.memberNickname = event.member.nickname;
     dto.memberProfile = event.member.memberDetail?.profilePicture;
-    dto.address = `${event.si} ${event.gu} ${event.dong}` as string;
+    dto.address = event.address;
     dto.title = event.title;
     dto.content = event.content;
     dto.media = event.media;

--- a/src/modules/events/entities/builder/event.builder.ts
+++ b/src/modules/events/entities/builder/event.builder.ts
@@ -1,5 +1,7 @@
 import { Event } from '../event.entity';
 import { Member } from '../../../members/entities';
+import { EventType } from '../enum/event-type.enum';
+import { DisasterLevel } from '../enum/disaster-level.enum';
 
 export class EventBuilder {
   _event: Event;
@@ -18,7 +20,7 @@ export class EventBuilder {
     return this;
   }
 
-  type(type: string): this {
+  type(type: EventType): this {
     this._event.type = type;
     return this;
   }
@@ -48,22 +50,12 @@ export class EventBuilder {
     return this;
   }
 
-  si(si: string): this {
-    this._event.si = si;
+  address(address: string): this {
+    this._event.address = address;
     return this;
   }
 
-  gu(gu: string): this {
-    this._event.gu = gu;
-    return this;
-  }
-
-  dong(dong: string): this {
-    this._event.dong = dong;
-    return this;
-  }
-
-  disasterLevel(disasterLevel: string): this {
+  disasterLevel(disasterLevel: DisasterLevel): this {
     this._event.disasterLevel = disasterLevel;
     return this;
   }

--- a/src/modules/events/entities/enum/disaster-level.enum.ts
+++ b/src/modules/events/entities/enum/disaster-level.enum.ts
@@ -1,4 +1,4 @@
-export enum EventType {
+export enum DisasterLevel {
   PRIMARY = 'PRIMARY',
   SECONDARY = 'SECONDARY',
 }

--- a/src/modules/events/entities/enum/event-type.enum.ts
+++ b/src/modules/events/entities/enum/event-type.enum.ts
@@ -1,0 +1,10 @@
+export enum EventType {
+  FIRE = 'FIRE',
+  TYPHOON = 'TYPHOON',
+  EARTHQUAKE = 'EARTHQUAKE',
+  WAR = 'WAR',
+  FLOOD = 'FLOOD',
+  ACCIDENT = 'ACCIDENT',
+  OTHER = 'OTHER',
+  NONE = 'NONE',
+}

--- a/src/modules/events/entities/event.entity.ts
+++ b/src/modules/events/entities/event.entity.ts
@@ -9,6 +9,8 @@ import {
 import { Member } from '../../members/entities';
 import { DefaultEntity } from '../../../common/default.entity';
 import { Comment } from './comment.entity';
+import { DisasterLevel } from './enum/disaster-level.enum';
+import { EventType } from './enum/event-type.enum';
 
 @Entity()
 export class Event extends DefaultEntity {
@@ -20,7 +22,7 @@ export class Event extends DefaultEntity {
   member!: Member;
 
   @Column({ type: 'varchar', length: 10, nullable: true })
-  type!: string;
+  type?: EventType;
 
   @Column({ type: 'text', nullable: true })
   media?: string;
@@ -37,17 +39,11 @@ export class Event extends DefaultEntity {
   @Column({ type: 'decimal', precision: 16, scale: 13 })
   longitude!: number;
 
-  @Column({ type: 'varchar', length: 25 })
-  si!: string;
-
-  @Column({ type: 'varchar', length: 25 })
-  gu!: string;
-
-  @Column({ type: 'varchar', length: 25 })
-  dong!: string;
+  @Column({ type: 'varchar', length: 255 })
+  address!: string;
 
   @Column({ type: 'varchar', length: 25, nullable: true })
-  disasterLevel?: string;
+  disasterLevel!: DisasterLevel;
 
   @Column({ type: 'int', default: 0 })
   likesCount: number = 0;

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -30,6 +30,7 @@ import { ApiSuccessResponse } from '../../common/decorators/decorators.success.r
 import { ApiFailureResponse } from '../../common/decorators/decoratos.failure.response';
 import { ErrorStatus } from '../../common/api/status/error.status';
 import { GetFeedsDto } from './dto/get-feeds.dto';
+import { EventType } from './entities/enum/event-type.enum';
 
 @ApiBearerAuth()
 @ApiTags('Events')
@@ -54,6 +55,14 @@ export class EventsController {
           content: { type: 'string' },
           latitude: { type: 'number' },
           longitude: { type: 'number' },
+          address: { type: 'string' },
+          type: {
+            type: 'string',
+            description:
+              Object.values(EventType)
+                .map((type) => `${type}`)
+                .join(', ') + '.',
+          },
         },
         media: {
           type: 'string',
@@ -74,8 +83,8 @@ export class EventsController {
     @Request() req,
     @UploadedFile() media: Express.Multer.File,
   ): Promise<void> {
-    const memberId = req.user.id;
-    await this.eventsService.create(request, memberId, media);
+    const member = req.user;
+    await this.eventsService.create(request, member, media);
   }
 
   @Get('nearby')

--- a/src/modules/events/service/events.service.ts
+++ b/src/modules/events/service/events.service.ts
@@ -13,6 +13,7 @@ import { GetFeedsDto } from '../dto/get-feeds.dto';
 import { LikeRepository } from '../repository/like.repository';
 import { LikeBuilder } from '../entities/builder/like.builder';
 import { FindEventDto } from '../dto/find-event.dto';
+import { Member } from '../../members/entities';
 
 @Injectable()
 export class EventsService {
@@ -26,22 +27,14 @@ export class EventsService {
 
   async create(
     request: CreateEventDto,
-    memberId: number,
+    member: Member,
     media: Express.Multer.File | null,
   ): Promise<void> {
-    const member = await this.membersRepository.findById(memberId);
-    if (!member) {
-      throw new ExceptionHandler(ErrorStatus.MEMBER_NOT_FOUND);
-    }
     if (!request.content && !media) {
       throw new ExceptionHandler(ErrorStatus.EVENT_CONTENTS_NOT_FOUND);
     }
     const url = media ? await this.s3Service.upload(media) : undefined;
-    const region = await this.naverService.getAddressFromCoordinate(
-      request.latitude,
-      request.longitude,
-    );
-    const event = request.toEvent(region, member, url);
+    const event = request.toEvent(member, url);
     await this.eventsRepository.create(event);
   }
 

--- a/test/unit/events.service.spec.ts
+++ b/test/unit/events.service.spec.ts
@@ -80,13 +80,10 @@ describe('EventService', () => {
   describe('create', () => {
     let request: CreateEventDto;
     let member: Member;
-    let memberId: number;
     let media: Express.Multer.File;
-    let region: any;
     let event: Event;
 
     beforeEach(() => {
-      memberId = 1;
       media = { originalname: 'test.jpg', buffer: Buffer.from('test') } as any;
 
       request = Object.assign(new CreateEventDto(), {
@@ -98,40 +95,21 @@ describe('EventService', () => {
 
       member = new Member();
       event = new Event();
-      region = { city: 'Seoul', gu: 'gu', dong: 'dong' };
-    });
-    it('should throw MEMBER_NOT_FOUND if member does not exist', async () => {
-      jest.spyOn(memberRepository, 'findById').mockResolvedValue(null);
-      await expect(
-        eventService.create(request, memberId, media),
-      ).rejects.toThrow(new ExceptionHandler(ErrorStatus.MEMBER_NOT_FOUND));
     });
 
     it('should throw EVENT_CONTENTS_NOT_FOUND if both image and content are empty', async () => {
-      jest.spyOn(memberRepository, 'findById').mockResolvedValue(member);
       request.content = '';
-      await expect(
-        eventService.create(request, memberId, null),
-      ).rejects.toThrow(
+      await expect(eventService.create(request, member, null)).rejects.toThrow(
         new ExceptionHandler(ErrorStatus.EVENT_CONTENTS_NOT_FOUND),
       );
     });
 
     it('should create an event successfully', async () => {
-      jest.spyOn(memberRepository, 'findById').mockResolvedValue(member);
       jest.spyOn(eventRepository, 'create').mockResolvedValue(event);
-      jest
-        .spyOn(naverService, 'getAddressFromCoordinate')
-        .mockResolvedValue(region);
 
-      await eventService.create(request, memberId, media);
+      await eventService.create(request, member, media);
 
-      expect(memberRepository.findById).toHaveBeenCalledWith(memberId);
       expect(s3Service.upload).toHaveBeenCalledWith(media);
-      expect(naverService.getAddressFromCoordinate).toHaveBeenCalledWith(
-        request.latitude,
-        request.longitude,
-      );
       expect(eventRepository.create).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## #️⃣Related Issue
> #60

## 📝Work Description
1. 시,구,동을 address로 수정. 프론트에서 address를 넘겨주면 저장할 수 있게 수정
2. disaterLevel, type을 enum으로 수정
- 스웨거에 type 값들이 뭔지 표시해둠
<img width="661" alt="image" src="https://github.com/user-attachments/assets/76bf6b23-190b-4c36-87f8-b9c5f51e9651">


4. member를 2번 조회하고 있어서 service단에서 멤버 조회 안하게 수정 -> 이미 토큰 값으로 멤버를 조회하고 있었음
5. 테스트 코드 수정
<img width="385" alt="image" src="https://github.com/user-attachments/assets/195b71bf-a318-4bc2-a10d-8c6e0f908abe">
