### PR TITLE
Fix get event api

### DIFF
--- a/src/common/api/status/error.status.ts
+++ b/src/common/api/status/error.status.ts
@@ -82,6 +82,11 @@ export class ErrorStatus implements BaseCode {
     400,
     '유효한 위도와 경도를 입력해 주세요.',
   );
+  static readonly INVALID_DISASTER_LEVEL = new ErrorStatus(
+    false,
+    400,
+    '유효한 재난 단계를 입력해 주세요.',
+  );
 
   //S3 에러
   static readonly S3_UPLOAD_FAILURE = new ErrorStatus(

--- a/src/modules/events/dto/find-event.dto.ts
+++ b/src/modules/events/dto/find-event.dto.ts
@@ -11,7 +11,7 @@ class CommentDto {
   @ApiProperty()
   memberNickname: string;
   @ApiProperty()
-  memberProfile: string | null;
+  memberProfile: string;
   @ApiProperty()
   createdAt: Date;
   @ApiProperty()
@@ -22,7 +22,7 @@ class CommentDto {
     this.content = comment.content;
     this.memberId = comment.member.id;
     this.memberNickname = comment.member.nickname;
-    this.memberProfile = comment.member.memberDetail?.profilePicture ?? null;
+    this.memberProfile = comment.member.memberDetail!.profilePicture!;
     this.createdAt = comment.createdAt;
     this.updatedAt = comment.updatedAt;
   }
@@ -34,7 +34,7 @@ export class FindEventDto {
   @ApiProperty()
   memberNickname!: string;
   @ApiProperty()
-  memberProfile?: string;
+  memberProfile!: string;
   @ApiProperty()
   address!: string;
   @ApiProperty()
@@ -61,7 +61,7 @@ export class FindEventDto {
     });
     dto.id = event.id;
     dto.memberNickname = event.member.nickname;
-    dto.memberProfile = event.member.memberDetail?.profilePicture;
+    dto.memberProfile = event.member.memberDetail!.profilePicture!;
     dto.address = event.address;
     dto.title = event.title;
     dto.content = event.content;

--- a/src/modules/events/dto/find-nearyby-events.dto.ts
+++ b/src/modules/events/dto/find-nearyby-events.dto.ts
@@ -1,5 +1,6 @@
 import { Event } from '../entities';
 import { ApiProperty } from '@nestjs/swagger';
+import { EventType } from '../entities/enum/event-type.enum';
 
 export class nearbyEvent {
   @ApiProperty()
@@ -10,11 +11,20 @@ export class nearbyEvent {
   latitude: number;
   @ApiProperty()
   media?: string;
-  constructor(id: number, longitude: number, latitude: number, media?: string) {
+  @ApiProperty()
+  eventType: EventType;
+  constructor(
+    id: number,
+    longitude: number,
+    latitude: number,
+    eventType: EventType,
+    media?: string,
+  ) {
     this.id = id;
     this.latitude = latitude;
     this.longitude = longitude;
     this.media = media;
+    this.eventType = eventType;
   }
 }
 
@@ -26,7 +36,13 @@ export class FindNearybyDto {
     const dto = new FindNearybyDto();
     dto.events = events.map(
       (event) =>
-        new nearbyEvent(event.id, event.longitude, event.latitude, event.media),
+        new nearbyEvent(
+          event.id,
+          event.longitude,
+          event.latitude,
+          event.type!,
+          event.media,
+        ),
     );
     return dto;
   }

--- a/src/modules/events/entities/enum/disaster-level.enum.ts
+++ b/src/modules/events/entities/enum/disaster-level.enum.ts
@@ -1,4 +1,5 @@
 export enum DisasterLevel {
   PRIMARY = 'PRIMARY',
   SECONDARY = 'SECONDARY',
+  ALL = 'ALL',
 }

--- a/src/modules/events/service/events.service.ts
+++ b/src/modules/events/service/events.service.ts
@@ -14,6 +14,7 @@ import { LikeRepository } from '../repository/like.repository';
 import { LikeBuilder } from '../entities/builder/like.builder';
 import { FindEventDto } from '../dto/find-event.dto';
 import { Member } from '../../members/entities';
+import { DisasterLevel } from '../entities/enum/disaster-level.enum';
 
 @Injectable()
 export class EventsService {
@@ -47,9 +48,21 @@ export class EventsService {
     return FindEventDto.of(event, isLiked);
   }
 
-  async findNearby(lat: number, lng: number): Promise<Event[]> {
-    if (!lat || !lng || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+  async findNearby(lat: number, lng: number, level: string): Promise<Event[]> {
+    if (
+      lat === undefined ||
+      lat === null ||
+      lat < -90 ||
+      lat > 90 ||
+      lng === undefined ||
+      lng === null ||
+      lng < -180 ||
+      lng > 180
+    ) {
       throw new ExceptionHandler(ErrorStatus.INVALID_GEO_LOCATION);
+    }
+    if (!(level.toUpperCase() in DisasterLevel)) {
+      throw new ExceptionHandler(ErrorStatus.INVALID_DISASTER_LEVEL);
     }
     const earthRadius = 6371000;
     const latDistance = 200 / earthRadius;
@@ -65,6 +78,7 @@ export class EventsService {
       maxLat,
       minLng,
       maxLng,
+      level,
     );
   }
 

--- a/src/modules/members/entities/member.entity.ts
+++ b/src/modules/members/entities/member.entity.ts
@@ -28,7 +28,7 @@ export class Member extends DefaultEntity {
   @Column({ type: 'decimal', precision: 16, scale: 13 })
   longitude: number = 127.08342026545051;
 
-  @Column({ type: 'text' })
+  @Column({ type: 'text', nullable: true })
   device!: string;
 
   @OneToOne(() => MemberDetail, (memberDetail) => memberDetail.member, {

--- a/test/unit/events.service.spec.ts
+++ b/test/unit/events.service.spec.ts
@@ -153,8 +153,10 @@ describe('EventService', () => {
   describe('findNearby', () => {
     let lat: number;
     let lng: number;
+    let level: string;
     let events: Event[];
     beforeEach(() => {
+      level = 'primary';
       lat = 37.5665;
       lng = 126.978;
       events = [
@@ -183,14 +185,20 @@ describe('EventService', () => {
     });
     it('should return the events nearby', async () => {
       jest.spyOn(eventRepository, 'findNearby').mockResolvedValue(events);
-      const result = await eventService.findNearby(lat, lng);
+      const result = await eventService.findNearby(lat, lng, level);
       expect(result).toEqual(events);
     });
     it('should throw INVALID_GEO_LOCATION if the lat or lng is not valid', async () => {
       lat = 100.5665;
       lng = 186.978;
-      await expect(eventService.findNearby(lat, lng)).rejects.toThrow(
+      await expect(eventService.findNearby(lat, lng, level)).rejects.toThrow(
         new ExceptionHandler(ErrorStatus.INVALID_GEO_LOCATION),
+      );
+    });
+    it('should throw INVALID_DISASTER_LEVEL if invalid level is requested', async () => {
+      level = 'wrong';
+      await expect(eventService.findNearby(lat, lng, level)).rejects.toThrow(
+        new ExceptionHandler(ErrorStatus.INVALID_DISASTER_LEVEL),
       );
     });
   });
@@ -247,7 +255,7 @@ describe('EventService', () => {
     it('should throw INVALID_GEO_LOCATION if the lat or lng is not valid', async () => {
       lat = 100.5665;
       lng = 186.978;
-      await expect(eventService.findNearby(lat, lng)).rejects.toThrow(
+      await expect(eventService.findNearybyAll(lat, lng)).rejects.toThrow(
         new ExceptionHandler(ErrorStatus.INVALID_GEO_LOCATION),
       );
     });


### PR DESCRIPTION
## #️⃣Related Issue
> #63

## 📝Work Description
1. 이벤트 조회할 때 재난 단계별로 조회할 수 있게 수정 (primary, secondary, all) 
2. 이벤트 조회 시 eventType도 추가적으로 반환
<img width="673" alt="image" src="https://github.com/user-attachments/assets/18a373eb-0cd6-46ea-94a0-c7bc1df4789e">

<img width="463" alt="image" src="https://github.com/user-attachments/assets/c6cf96e3-14bb-4ebd-b894-2bad88b11d17">

3. 테스트 코드 수정
4. 회원가입 시 device 토큰 오류 해결 <- nullable=true 추가해줌