### PR TITLE
:hammer: [Fix] Fix favorite request api

### DIFF
--- a/src/modules/alarm/alarm.module.ts
+++ b/src/modules/alarm/alarm.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { AlarmController } from './alarm.controller';
 import { AlarmService } from './alarm.service';
 import { MembersModule } from '../members/members.module';
@@ -6,8 +6,12 @@ import { ExternalModule } from '../../external/external.module';
 import { AlarmRepository } from './alarm.repository';
 
 @Module({
-  imports: [MembersModule, ExternalModule],
+  imports: [
+    forwardRef(() => MembersModule), // forwardRef로 수정
+    ExternalModule,
+  ],
   controllers: [AlarmController],
   providers: [AlarmService, AlarmRepository],
+  exports: [AlarmRepository],
 })
 export class AlarmModule {}

--- a/src/modules/members/entities/builder/favorite.builder.ts
+++ b/src/modules/members/entities/builder/favorite.builder.ts
@@ -1,0 +1,38 @@
+import { Favorite } from '../favorite.entity';
+import { Member } from '../member.entity';
+
+export class FavoriteBuilder {
+  private _favorite: Favorite;
+  constructor() {
+    this._favorite = new Favorite();
+  }
+
+  id(id: number): this {
+    this._favorite.id = id;
+    return this;
+  }
+
+  member(member: Member): this {
+    this._favorite.member = member;
+    return this;
+  }
+
+  favoritedMember(member: Member): this {
+    this._favorite.member = member;
+    return this;
+  }
+
+  isAccepted(boolean: boolean): this {
+    this._favorite.isAccepted = boolean;
+    return this;
+  }
+
+  nickname(nickname: string): this {
+    this._favorite.nickname = nickname;
+    return this;
+  }
+
+  build(): Favorite {
+    return this._favorite;
+  }
+}

--- a/src/modules/members/members.controller.ts
+++ b/src/modules/members/members.controller.ts
@@ -92,8 +92,8 @@ export class MembersController {
     @Request() req,
     @Param('nickname') nickname: string,
   ): Promise<void> {
-    const memberId = req.user.id; // 현재 로그인된 사용자의 ID
-    await this.favoritesService.addFavorite(memberId, nickname);
+    const member = req.user; // 현재 로그인된 사용자
+    await this.favoritesService.addFavorite(member, nickname);
   }
 
   // 관심 사용자 요청 수락 API

--- a/src/modules/members/members.module.ts
+++ b/src/modules/members/members.module.ts
@@ -1,17 +1,19 @@
-import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { forwardRef, Module } from '@nestjs/common';
 import { MembersService } from './services/members.service';
 import { FavoritesService } from './services/favorites.service';
 import { MembersController } from './members.controller';
 import { MembersRepository } from './repository/members.repository';
 import { FavoritesRepository } from './repository/favorites.repository';
-import { Member } from './entities';
 import { LocationService } from './services/location.service';
 import { ExternalModule } from 'src/external/external.module';
 import { MembersDetailRepository } from './repository/membersDetail.repository';
+import { AlarmModule } from '../alarm/alarm.module';
 
 @Module({
-  imports: [ExternalModule],
+  imports: [
+    ExternalModule,
+    forwardRef(() => AlarmModule), // forwardRef로 수정
+  ],
   providers: [
     MembersService,
     MembersRepository,


### PR DESCRIPTION
## #️⃣Related Issue
> #81

## 📝Work Description
1. 즐겨찾기 요청을 보내면 notification 테이블에 알림이 생성되게 수정
2. 테스트 코드 수정

요청을 보내면 이렇게 favorite, notification 테이블에 데이터가 생성됨

<img width="1697" alt="image" src="https://github.com/user-attachments/assets/b26228ab-8281-41b7-b049-30c2a14ff551">


<img width="1809" alt="image" src="https://github.com/user-attachments/assets/b217ffc8-cb44-48cc-98a7-5913ce10e074">

