### PR TITLE
:sparkles: [Feat] Create primary event api

### DIFF
--- a/src/modules/alarm/notification.module.ts
+++ b/src/modules/alarm/notification.module.ts
@@ -17,6 +17,6 @@ import { NotificationActionService } from './services/notification-action.servic
     NotificationRepository,
     NotificationActionService,
   ],
-  exports: [NotificationRepository],
+  exports: [NotificationService, NotificationRepository],
 })
 export class NotificationModule {}

--- a/src/modules/alarm/services/notification.service.ts
+++ b/src/modules/alarm/services/notification.service.ts
@@ -65,6 +65,22 @@ export class NotificationService {
     return new GetNotificationsDto(await notificationDtos);
   }
 
+  async createNotification(
+    type: NotificationType,
+    member: Member,
+    referenceId: number,
+    referenceTable: string,
+  ): Promise<Notification> {
+    const notification = new NotificationBuilder()
+      .type(type)
+      .member(member)
+      .referenceTable(referenceTable)
+      .referenceId(referenceId)
+      .isRead(false)
+      .build();
+    return this.notificationRepository.create(notification);
+  }
+
   private async formatNotificationDetails(notification: Notification) {
     const actionDetails =
       await this.notificationActionService.getActionDetails(notification);

--- a/src/modules/events/dto/search-event.dto.ts
+++ b/src/modules/events/dto/search-event.dto.ts
@@ -51,7 +51,6 @@ export class SearchEventDto {
   }
 
   static of(events: Event[]): SearchEventDto {
-    console.log(events);
     const eventList = events.map((event) => {
       return new EventDto(
         event.id,

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -23,6 +23,7 @@ import {
   ApiBearerAuth,
   ApiBody,
   ApiConsumes,
+  ApiExcludeEndpoint,
   ApiOperation,
   ApiTags,
 } from '@nestjs/swagger';
@@ -204,5 +205,17 @@ export class EventsController {
     @Query('keyword') keyword: string,
   ): Promise<SearchEventDto> {
     return await this.eventsService.searchEvent(keyword);
+  }
+
+  @Post('/admin/primary')
+  @UseInterceptors(FileInterceptor('media'))
+  @ApiExcludeEndpoint()
+  async createPrimary(
+    @Body() request: CreateEventDto,
+    @Request() req,
+    @UploadedFile() media: Express.Multer.File,
+  ) {
+    const member = req.user;
+    await this.eventsService.createPrimary(request, member, media);
   }
 }

--- a/src/modules/events/events.module.ts
+++ b/src/modules/events/events.module.ts
@@ -7,9 +7,10 @@ import { CommentRepository } from './repository/comment.repository';
 import { MembersModule } from '../members/members.module';
 import { ExternalModule } from 'src/external/external.module';
 import { LikeRepository } from './repository/like.repository';
+import { NotificationModule } from '../alarm/notification.module';
 
 @Module({
-  imports: [MembersModule, ExternalModule],
+  imports: [MembersModule, ExternalModule, NotificationModule],
   controllers: [EventsController],
   providers: [
     EventsService,

--- a/src/modules/members/services/members.service.ts
+++ b/src/modules/members/services/members.service.ts
@@ -100,7 +100,16 @@ export class MembersService {
   }
 
   async findNearbyMembers(lat: number, lng: number): Promise<Member[]> {
-    if (!lat || !lng || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+    if (
+      lat === undefined ||
+      lat === null ||
+      lat < -90 ||
+      lat > 90 ||
+      lng === undefined ||
+      lng === null ||
+      lng < -180 ||
+      lng > 180
+    ) {
       throw new ExceptionHandler(ErrorStatus.INVALID_GEO_LOCATION);
     }
     const earthRadius = 6371000;

--- a/test/unit/members/favorites.service.spec.ts
+++ b/test/unit/members/favorites.service.spec.ts
@@ -10,13 +10,15 @@ import { NotificationRepository } from '../../../src/modules/alarm/notification.
 import { MemberBuilder } from '../../../src/modules/members/entities/builder/member.builder';
 import { FavoriteBuilder } from '../../../src/modules/members/entities/builder/favorite.builder';
 import { NotificationType } from '../../../src/modules/alarm/entities/enums/notificationType.enum';
+import { NotificationService } from '../../../src/modules/alarm/services/notification.service';
 
 describe('FavoritesService', () => {
   let favoritesService: FavoritesService;
   let membersRepository: MembersRepository;
   let favoritesRepository: FavoritesRepository;
   let naverService: NaverService;
-  let alarmRepository: NotificationRepository;
+  let notificationRepository: NotificationRepository;
+  let notificationService: NotificationService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -52,6 +54,12 @@ describe('FavoritesService', () => {
             create: jest.fn(),
           },
         },
+        {
+          provide: NotificationService,
+          useValue: {
+            createNotification: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
@@ -59,9 +67,10 @@ describe('FavoritesService', () => {
     membersRepository = module.get<MembersRepository>(MembersRepository);
     favoritesRepository = module.get<FavoritesRepository>(FavoritesRepository);
     naverService = module.get<NaverService>(NaverService);
-    alarmRepository = module.get<NotificationRepository>(
+    notificationRepository = module.get<NotificationRepository>(
       NotificationRepository,
     );
+    notificationService = module.get<NotificationService>(NotificationService);
   });
 
   describe('addFavorite', () => {
@@ -106,15 +115,7 @@ describe('FavoritesService', () => {
       expect(favoritesRepository.saveFavorite).toHaveBeenCalledWith(
         newFavorite,
       );
-      expect(alarmRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: NotificationType.FAVORITE_REQUEST,
-          member: targetMember,
-          referenceTable: 'favorite',
-          referenceId: favorite.id,
-          isRead: false,
-        }),
-      );
+      expect(notificationService.createNotification).toHaveBeenCalledTimes(1);
     });
 
     it('should throw an error if the target member does not found', async () => {


### PR DESCRIPTION
## #️⃣Related Issue
> #96

## 📝Work Description
1. Primary event 생성 api 구현 -> 이건 관리자만 사용할거여서 따로 스웨거에 등록하지는 않음
- Primary event를 등록하면 주변 사용자를 검색 후 notification 생성
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/0cf1be5e-4e0f-4419-978f-13a4d2548ee2">

2. notificationRepository 대신 notificationServcie를 사용하도록 변경
3. 불필요한 console.log() 삭제
4. 테스트 코드 작성
<img width="631" alt="image" src="https://github.com/user-attachments/assets/d4ee8843-c5c1-47c4-9ff4-db6e3bddec9c">

