### PR TITLE
:sparkles: [Fix] Add NEARBY_EVENT type to the api

### DIFF
--- a/src/modules/alarm/notification.module.ts
+++ b/src/modules/alarm/notification.module.ts
@@ -5,11 +5,13 @@ import { MembersModule } from '../members/members.module';
 import { ExternalModule } from '../../external/external.module';
 import { NotificationRepository } from './notification.repository';
 import { NotificationActionService } from './services/notification-action.service';
+import { EventsModule } from '../events/events.module';
 
 @Module({
   imports: [
     forwardRef(() => MembersModule), // forwardRef로 수정
     ExternalModule,
+    forwardRef(() => EventsModule),
   ],
   controllers: [NotificationController],
   providers: [
@@ -17,6 +19,6 @@ import { NotificationActionService } from './services/notification-action.servic
     NotificationRepository,
     NotificationActionService,
   ],
-  exports: [NotificationService, NotificationRepository],
+  exports: [NotificationService],
 })
 export class NotificationModule {}

--- a/src/modules/events/events.module.ts
+++ b/src/modules/events/events.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { EventsService } from './services/events.service';
 import { EventsController } from './events.controller';
 import { EventsRepository } from './repository/events.repository';
@@ -10,7 +10,11 @@ import { LikeRepository } from './repository/like.repository';
 import { NotificationModule } from '../alarm/notification.module';
 
 @Module({
-  imports: [MembersModule, ExternalModule, NotificationModule],
+  imports: [
+    MembersModule,
+    ExternalModule,
+    forwardRef(() => NotificationModule),
+  ],
   controllers: [EventsController],
   providers: [
     EventsService,
@@ -19,5 +23,6 @@ import { NotificationModule } from '../alarm/notification.module';
     CommentRepository,
     LikeRepository,
   ],
+  exports: [EventsRepository],
 })
 export class EventsModule {}


### PR DESCRIPTION
## #️⃣Related Issue
> #100

## 📝Work Description
1. 알림 조회하면 주변에서 발생한 중요한 사건에 대해서도 조회할 수 있게 수정
<img width="576" alt="image" src="https://github.com/user-attachments/assets/ec73b125-e985-4dda-8993-5af382f634c8">

2. 기존 알림 메시지를 생성하는 로직이 switch-case로 되어 있었음. 근데 나중에 알림이 추가되면 case를 하나씩 다 등록해줘야 해서 확장성이 떨어지기 때문에 객체 매핑 방식으로 수정
3. 테스트 코드 작성
<img width="652" alt="image" src="https://github.com/user-attachments/assets/90253953-15ea-4284-879e-a76d669c362b">

