### PR TITLE
:sparkles: [Fix] Implement delete favorite member api

### DIFF
--- a/src/external/naver/naver.service.ts
+++ b/src/external/naver/naver.service.ts
@@ -37,7 +37,8 @@ export class NaverService {
     );
     const result = response.data.results[0];
     if (!result) {
-      throw new ExceptionHandler(ErrorStatus.INVALID_GEO_LOCATION);
+      return '';
+      // throw new ExceptionHandler(ErrorStatus.INVALID_GEO_LOCATION);
     }
     const city = result.region.area1.name;
     const gu = result.region.area2.name;

--- a/src/modules/members/members.controller.ts
+++ b/src/modules/members/members.controller.ts
@@ -11,6 +11,8 @@ import {
   Body,
   Patch,
   UploadedFile,
+  Delete,
+  Req,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { MembersService } from './services/members.service';
@@ -205,5 +207,14 @@ export class MembersController {
   )
   async findMemberById(@Param('id') id: string): Promise<GetMemberInfoDto> {
     return await this.membersService.findMemberById(Number(id));
+  }
+
+  @Delete('favorites/:id')
+  @ApiOperation({ summary: 'Delete favorite member' })
+  @ApiSuccessResponse()
+  @ApiFailureResponse(ErrorStatus.INTERNAL_SERVER_ERROR)
+  async deleteFavorite(@Param('id') id: string, @Req() req): Promise<void> {
+    const memberId = req.user.id;
+    return await this.favoritesService.deleteFavorite(memberId, Number(id));
   }
 }

--- a/src/modules/members/repository/favorites.repository.ts
+++ b/src/modules/members/repository/favorites.repository.ts
@@ -58,4 +58,14 @@ export class FavoritesRepository {
       .leftJoinAndSelect('favorite.favoritedMember', 'favoritedMember')
       .getOne();
   }
+
+  async deleteById(id: number, memberId: number): Promise<void> {
+    await this.favoriteRepository
+      .createQueryBuilder('favorite')
+      .delete()
+      .from(Favorite)
+      .where('favorite.id = :id', { id })
+      .andWhere('favorite.memberId = :memberId', { memberId })
+      .execute();
+  }
 }

--- a/src/modules/members/services/favorites.service.ts
+++ b/src/modules/members/services/favorites.service.ts
@@ -127,4 +127,8 @@ export class FavoritesService {
 
     await this.favoritesRepository.updateFavorite(favorite);
   }
+
+  async deleteFavorite(memberId: number, favoriteId: number): Promise<void> {
+    await this.favoritesRepository.deleteById(favoriteId, memberId);
+  }
 }

--- a/test/unit/members/favorites.service.spec.ts
+++ b/test/unit/members/favorites.service.spec.ts
@@ -9,7 +9,6 @@ import { NaverService } from 'src/external/naver/naver.service';
 import { NotificationRepository } from '../../../src/modules/alarm/notification.repository';
 import { MemberBuilder } from '../../../src/modules/members/entities/builder/member.builder';
 import { FavoriteBuilder } from '../../../src/modules/members/entities/builder/favorite.builder';
-import { NotificationType } from '../../../src/modules/alarm/entities/enums/notificationType.enum';
 import { NotificationService } from '../../../src/modules/alarm/services/notification.service';
 
 describe('FavoritesService', () => {
@@ -17,7 +16,6 @@ describe('FavoritesService', () => {
   let membersRepository: MembersRepository;
   let favoritesRepository: FavoritesRepository;
   let naverService: NaverService;
-  let notificationRepository: NotificationRepository;
   let notificationService: NotificationService;
 
   beforeEach(async () => {
@@ -40,6 +38,7 @@ describe('FavoritesService', () => {
             updateFavorite: jest.fn(),
             removeFavorite: jest.fn(),
             findAllFavoritesForMember: jest.fn(),
+            deleteById: jest.fn(),
           },
         },
         {
@@ -67,9 +66,6 @@ describe('FavoritesService', () => {
     membersRepository = module.get<MembersRepository>(MembersRepository);
     favoritesRepository = module.get<FavoritesRepository>(FavoritesRepository);
     naverService = module.get<NaverService>(NaverService);
-    notificationRepository = module.get<NotificationRepository>(
-      NotificationRepository,
-    );
     notificationService = module.get<NotificationService>(NotificationService);
   });
 
@@ -387,6 +383,18 @@ describe('FavoritesService', () => {
       );
 
       expect(favoritesRepository.updateFavorite).not.toHaveBeenCalled();
+    });
+  });
+  describe('deleteFavorite', () => {
+    it('should delete the favoriteMember successfully', async () => {
+      const memberId = 1;
+      const favoriteId = 1;
+      await favoritesService.deleteFavorite(memberId, favoriteId);
+
+      expect(favoritesRepository.deleteById).toHaveBeenCalledWith(
+        favoriteId,
+        memberId,
+      );
     });
   });
 });


### PR DESCRIPTION
## #️⃣Related Issue
> #102 

## 📝Work Description
1. 즐겨찾기 리스트에서 지인 삭제 api 구현. deletedAt 값으로 구현하려고 했는데, 생성하는 부분 로직까지 다 수정해야 해서 일단은 테이블에서 다 삭제 처리함. 나중에 수정해야함
2. 위도, 경도로 주소 반환하는 함수에서 위도, 경도가 이상한 값은 아니지만 대한민국에 존재하지 않는 값이면 예외처리를 했는데 빈 문자열을 반환하는 걸로 수정. 테스트 할 때 계속 유요한 위도 경도를 줄려니까 너무 힘듬....
3. 테스트 코드 작성
<img width="652" alt="image" src="https://github.com/user-attachments/assets/de29b15a-99c5-4bc1-ba34-549da4af3e9d">

