### PR TITLE
:hammer: [Fix] Fix notification API for nearby events on favorite users

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/common": "^10.0.0",
         "@nestjs/config": "^3.2.3",
         "@nestjs/core": "^10.0.0",
+        "@nestjs/event-emitter": "^2.0.4",
         "@nestjs/jwt": "^10.2.0",
         "@nestjs/mapped-types": "^2.0.5",
         "@nestjs/passport": "^10.0.3",
@@ -3182,6 +3183,18 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/event-emitter": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/event-emitter/-/event-emitter-2.0.4.tgz",
+      "integrity": "sha512-quMiw8yOwoSul0pp3mOonGz8EyXWHSBTqBy8B0TbYYgpnG1Ix2wGUnuTksLWaaBiiOTDhciaZ41Y5fJZsSJE1Q==",
+      "dependencies": {
+        "eventemitter2": "6.4.9"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
+        "@nestjs/core": "^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/@nestjs/jwt": {
@@ -6725,6 +6738,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter2": {
+      "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
     },
     "node_modules/events": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.2.3",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/event-emitter": "^2.0.4",
     "@nestjs/jwt": "^10.2.0",
     "@nestjs/mapped-types": "^2.0.5",
     "@nestjs/passport": "^10.0.3",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { AuthModule } from './modules/auth/auth.module';
 import { MembersModule } from './modules/members/members.module';
 import { ExternalModule } from './external/external.module';
 import { NotificationModule } from './modules/alarm/notification.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { NotificationModule } from './modules/alarm/notification.module';
       isGlobal: true,
     }),
     TypeOrmModule.forRoot(typeOrmConfig),
+    EventEmitterModule.forRoot(),
     EventsModule,
     AuthModule,
     MembersModule,

--- a/src/modules/alarm/notification.controller.ts
+++ b/src/modules/alarm/notification.controller.ts
@@ -33,7 +33,10 @@ export class NotificationController {
     @Query('lng') lng: string,
   ) {
     const sender = await this.memberService.findByEmail(req.user.email);
-    const receivers = await this.memberService.findNearbyMembers(+lat, +lng);
+    const receivers = await this.memberService.findNearbyAndFavoritingMembers(
+      +lat,
+      +lng,
+    );
     await this.notificationService.sendNotificationsToNearby(receivers, sender);
   }
 

--- a/src/modules/alarm/notification.module.ts
+++ b/src/modules/alarm/notification.module.ts
@@ -6,6 +6,7 @@ import { ExternalModule } from '../../external/external.module';
 import { NotificationRepository } from './notification.repository';
 import { NotificationActionService } from './services/notification-action.service';
 import { EventsModule } from '../events/events.module';
+import { NotificationEventsHandler } from './services/notification-events.handler';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { EventsModule } from '../events/events.module';
     NotificationService,
     NotificationRepository,
     NotificationActionService,
+    NotificationEventsHandler,
   ],
   exports: [NotificationService],
 })

--- a/src/modules/alarm/services/notification-events.handler.ts
+++ b/src/modules/alarm/services/notification-events.handler.ts
@@ -1,0 +1,53 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { NotificationService } from './notification.service';
+import { OnEvent } from '@nestjs/event-emitter';
+import { Member } from '../../members/entities';
+import { NotificationType } from '../entities/enums/notificationType.enum';
+
+@Injectable()
+export class NotificationEventsHandler implements OnModuleInit {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  onModuleInit() {
+    console.log('NotificationEventsHandler initialized');
+  }
+
+  /**
+   * 주변 사용자들에게 알림 생성
+   */
+  @OnEvent('notify.nearby')
+  async handleNotifyNearbyEvent(payload: {
+    members: Member[];
+    eventId: number;
+  }) {
+    await Promise.all(
+      payload.members.map((member) => {
+        return this.notificationService.createNotification(
+          NotificationType.NEARBY_EVENT,
+          member,
+          payload.eventId,
+          'event',
+        );
+      }),
+    );
+  }
+
+  /**
+   * 사용자를 지인으로 등록한 사용자들에게 알림 생성
+   */
+  @OnEvent('notify.friends')
+  async handleNotifyFriendsEvent(payload: { members: Member[] }) {
+    await Promise.all(
+      payload.members.map((member) => {
+        member.favoritedByMembers.forEach((favoritedByMember) => {
+          return this.notificationService.createNotification(
+            NotificationType.FAVORITE_NEARBY_EVENT,
+            favoritedByMember.member,
+            member.id,
+            'member',
+          );
+        });
+      }),
+    );
+  }
+}

--- a/src/modules/members/entities/member.entity.ts
+++ b/src/modules/members/entities/member.entity.ts
@@ -1,6 +1,12 @@
-import { Column, Entity, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  OneToMany,
+  OneToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { DefaultEntity } from '../../../common/default.entity';
-import { MemberDetail, MemberNotification } from '.';
+import { Favorite, MemberDetail, MemberNotification } from '.';
 
 @Entity()
 export class Member extends DefaultEntity {
@@ -44,4 +50,7 @@ export class Member extends DefaultEntity {
     },
   )
   memberNotification?: MemberNotification;
+
+  @OneToMany(() => Favorite, (favorite) => favorite.favoritedMember)
+  favoritedByMembers!: Favorite[];
 }

--- a/src/modules/members/repository/members.repository.ts
+++ b/src/modules/members/repository/members.repository.ts
@@ -66,6 +66,13 @@ export class MembersRepository {
         minLng,
         maxLng,
       })
+      .leftJoinAndSelect(
+        'member.favoritedByMembers',
+        'favorites',
+        'favorites.isAccepted = :isAccepted',
+        { isAccepted: true },
+      ) // isAccepted가 true인 경우만 가져옴
+      .leftJoinAndSelect('favorites.member', 'favoritingMember') // 지인으로 등록한 사용자의 정보를 조인
       .getMany();
   }
 }

--- a/src/modules/members/services/members.service.ts
+++ b/src/modules/members/services/members.service.ts
@@ -99,7 +99,10 @@ export class MembersService {
     }
   }
 
-  async findNearbyMembers(lat: number, lng: number): Promise<Member[]> {
+  async findNearbyAndFavoritingMembers(
+    lat: number,
+    lng: number,
+  ): Promise<Member[]> {
     if (
       lat === undefined ||
       lat === null ||

--- a/test/unit/alarm/notification-events.handler.spec.ts
+++ b/test/unit/alarm/notification-events.handler.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationEventsHandler } from '../../../src/modules/alarm/services/notification-events.handler';
+import { NotificationService } from '../../../src/modules/alarm/services/notification.service';
+import { NotificationType } from '../../../src/modules/alarm/entities/enums/notificationType.enum';
+import { MemberBuilder } from '../../../src/modules/members/entities/builder/member.builder';
+
+describe('NotificationEventsHandler', () => {
+  let handler: NotificationEventsHandler;
+  let notificationService: NotificationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationEventsHandler,
+        {
+          provide: NotificationService,
+          useValue: {
+            createNotification: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    handler = module.get<NotificationEventsHandler>(NotificationEventsHandler);
+    notificationService = module.get<NotificationService>(NotificationService);
+  });
+
+  describe('handleNotifyNearbyEvent', () => {
+    it('should create notifications for nearby members', async () => {
+      const member1 = new MemberBuilder().id(1).build();
+      const member2 = new MemberBuilder().id(2).build();
+      const members = [member1, member2];
+      const payload = {
+        members,
+        eventId: 1,
+        eventType: NotificationType.NEARBY_EVENT,
+      };
+
+      await handler.handleNotifyNearbyEvent(payload);
+
+      expect(notificationService.createNotification).toHaveBeenCalledTimes(2);
+      members.forEach((member) => {
+        expect(notificationService.createNotification).toHaveBeenCalledWith(
+          NotificationType.NEARBY_EVENT,
+          member,
+          payload.eventId,
+          'event',
+        );
+      });
+    });
+  });
+
+  describe('handleNotifyFriendsEvent', () => {
+    it('should create notifications for members favorited by other users', async () => {
+      const member1 = new MemberBuilder().id(1).build();
+      const member2 = new MemberBuilder().id(2).build();
+      const favoritingMember1 = new MemberBuilder().id(3).build();
+      const favoritingMember2 = new MemberBuilder().id(4).build();
+
+      member1.favoritedByMembers = [
+        { member: favoritingMember1 } as any,
+        { member: favoritingMember2 } as any,
+      ];
+      member2.favoritedByMembers = [{ member: favoritingMember2 } as any];
+
+      const members = [member1, member2];
+      const payload = {
+        members,
+        eventType: NotificationType.FAVORITE_NEARBY_EVENT,
+      };
+      await handler.handleNotifyFriendsEvent(payload);
+      expect(notificationService.createNotification).toHaveBeenCalledTimes(3);
+      members.forEach((member) => {
+        member.favoritedByMembers.forEach((favoritedByMember) => {
+          expect(notificationService.createNotification).toHaveBeenCalledWith(
+            NotificationType.FAVORITE_NEARBY_EVENT,
+            favoritedByMember.member,
+            member.id,
+            'member',
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## #️⃣Related Issue
> #104

## 📝Work Description
1. 중요한 사건이 발생하면, 주변 사용자 + 사용자들을 지인으로 등록한 사용자들에게도 알림을 생성
<img width="1823" alt="image" src="https://github.com/user-attachments/assets/1478152f-5078-4cf4-a421-b0af42a04159">

2. 기존 방식대로 api를 수정하면 아래와 같은 과정으로 진행된다. 이 방식은 간 단계를 순차적으로 진행해서 사용자가 많아질 경우 시간이 많이 소요될 수 있다. 
- Primary 사건 발생 -> 사건이 발생한 위치 주변에 있는 사용자 탐색 -> 사용자들에게 알림 생성 및 발송 -> 사건 주변에 있는 사용자들을 지인으로 등록한 사용자들 탐색 -> 해당 사용자들에게 알림 생성 및 발송 -> 응답 반환

그래서 기존 방식에서 이벤트 호출 방식으로 수정했다.
- Primary 사건 발생 -> 사건이 발생한 위치 주변에 있는 사용자 탐색 -> 알림 생성 이벤트 호출 및 응답 반환

3. 테스트 코드 수정
<img width="647" alt="image" src="https://github.com/user-attachments/assets/baa9abf9-7eb5-46dc-b3cc-642beee642a4">

