### PR TITLE
:hammer: [Fix] Delete the notifications when accept/reject favorite apis are called

### DIFF
--- a/src/modules/alarm/notification.repository.ts
+++ b/src/modules/alarm/notification.repository.ts
@@ -34,4 +34,13 @@ export class NotificationRepository {
       .andWhere('notification.memberId=:memberId', { memberId })
       .execute();
   }
+
+  async deleteFavoriteNotification(favoriteId: number): Promise<void> {
+    await this.notificationRepository
+      .createQueryBuilder('notification')
+      .delete()
+      .where("notification.referenceTable = 'favorite'")
+      .andWhere('notification.referenceId = :favoriteId', { favoriteId })
+      .execute();
+  }
 }

--- a/src/modules/alarm/services/notification.service.ts
+++ b/src/modules/alarm/services/notification.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { FcmService } from '../../../external/firebase/fcm.service';
-import { Member } from '../../members/entities';
+import { Favorite, Member } from '../../members/entities';
 import {
   formatNotificationMessage,
   NotificationMessage,
@@ -83,6 +83,10 @@ export class NotificationService {
       .isRead(false)
       .build();
     return this.notificationRepository.create(notification);
+  }
+
+  async deleteFavoriteNotification(favorite: Favorite): Promise<void> {
+    await this.notificationRepository.deleteFavoriteNotification(favorite.id);
   }
 
   private async formatNotificationDetails(notification: Notification) {

--- a/src/modules/members/services/favorites.service.ts
+++ b/src/modules/members/services/favorites.service.ts
@@ -74,6 +74,7 @@ export class FavoritesService {
     }
 
     favorite.isAccepted = true;
+    await this.notificationService.deleteFavoriteNotification(favorite);
     await this.favoritesRepository.updateFavorite(favorite);
   }
 
@@ -90,7 +91,7 @@ export class FavoritesService {
     if (!favorite) {
       throw new ExceptionHandler(ErrorStatus.FAVORITE_REQUEST_NOT_FOUND);
     }
-
+    await this.notificationService.deleteFavoriteNotification(favorite);
     await this.favoritesRepository.removeFavorite(favorite);
   }
 

--- a/test/unit/alarm/notification.service.spec.ts
+++ b/test/unit/alarm/notification.service.spec.ts
@@ -7,6 +7,7 @@ import { MemberBuilder } from '../../../src/modules/members/entities/builder/mem
 import { NotificationBuilder } from '../../../src/modules/alarm/entities/builder/notification.builder';
 import { NotificationType } from '../../../src/modules/alarm/entities/enums/notificationType.enum';
 import { GetNotificationsDto } from '../../../src/modules/alarm/dto/get-notifications.dto';
+import { FavoriteBuilder } from '../../../src/modules/members/entities/builder/favorite.builder';
 
 describe('NotificationService', () => {
   let notificationService: NotificationService;
@@ -25,6 +26,7 @@ describe('NotificationService', () => {
             createNotifications: jest.fn(),
             getNotificationsByMember: jest.fn(),
             markAsRead: jest.fn(),
+            deleteFavoriteNotification: jest.fn(),
           },
         },
         {
@@ -95,6 +97,15 @@ describe('NotificationService', () => {
         member.id,
         notificationId,
       );
+    });
+  });
+  describe('deleteFavoriteNotification', () => {
+    it('should delete favorite notification', async () => {
+      const favorite = new FavoriteBuilder().id(1).build();
+      await notificationService.deleteFavoriteNotification(favorite);
+      expect(
+        notificatonRepository.deleteFavoriteNotification,
+      ).toHaveBeenCalledWith(favorite.id);
     });
   });
 });

--- a/test/unit/members/favorites.service.spec.ts
+++ b/test/unit/members/favorites.service.spec.ts
@@ -6,7 +6,6 @@ import { Favorite, Member } from 'src/modules/members/entities';
 import { ExceptionHandler } from 'src/common/filters/exception/exception.handler';
 import { ErrorStatus } from 'src/common/api/status/error.status';
 import { NaverService } from 'src/external/naver/naver.service';
-import { NotificationRepository } from '../../../src/modules/alarm/notification.repository';
 import { MemberBuilder } from '../../../src/modules/members/entities/builder/member.builder';
 import { FavoriteBuilder } from '../../../src/modules/members/entities/builder/favorite.builder';
 import { NotificationService } from '../../../src/modules/alarm/services/notification.service';
@@ -48,15 +47,10 @@ describe('FavoritesService', () => {
           },
         },
         {
-          provide: NotificationRepository,
-          useValue: {
-            create: jest.fn(),
-          },
-        },
-        {
           provide: NotificationService,
           useValue: {
             createNotification: jest.fn(),
+            deleteFavoriteNotification: jest.fn(),
           },
         },
       ],
@@ -183,6 +177,9 @@ describe('FavoritesService', () => {
       );
       expect(favoritesRepository.updateFavorite).toHaveBeenCalledWith(favorite);
       expect(favorite.isAccepted).toBe(true);
+      expect(
+        notificationService.deleteFavoriteNotification,
+      ).toHaveBeenCalledWith(favorite);
     });
 
     it('should throw an error if the favorite request is not found', async () => {
@@ -243,6 +240,9 @@ describe('FavoritesService', () => {
 
       expect(favoritesRepository.findFavorite).toHaveBeenCalledWith(2, 1);
       expect(favoritesRepository.removeFavorite).toHaveBeenCalledWith(favorite);
+      expect(
+        notificationService.deleteFavoriteNotification,
+      ).toHaveBeenCalledWith(favorite);
     });
 
     it('should throw an error if the favorite request is not found', async () => {


### PR DESCRIPTION
## #️⃣Related Issue
> #119

## 📝Work Description
1. 즐겨찾기 수락/거절 api 호출 시 즐겨찾기 관련 알림 삭제
2. 테스트 코드 수정
<img width="668" alt="image" src="https://github.com/user-attachments/assets/9e2bdcdb-4404-4032-b4d6-949f52236a34">

