### PR TITLE
:sparkles: [Feat] Implement update member detail api

### DIFF
--- a/src/modules/members/dto/update-member-detail.dto.ts
+++ b/src/modules/members/dto/update-member-detail.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Member, MemberDetail } from '../entities';
+import { MemberDetailBuilder } from '../entities/builder/memberDetail.builder';
+
+export class UpdateMemberDetailDto {
+  @ApiProperty()
+  sex?: string;
+
+  @ApiProperty()
+  birthDate?: Date;
+
+  @ApiProperty()
+  height?: number;
+
+  @ApiProperty()
+  weight?: number;
+
+  @ApiProperty()
+  bloodType?: string;
+
+  @ApiProperty()
+  disease?: string;
+
+  @ApiProperty()
+  medication?: string;
+
+  toEntity(member: Member): MemberDetail {
+    const builder = new MemberDetailBuilder().member(member);
+    if (this.sex !== undefined) {
+      builder.sex(this.sex);
+    }
+    if (this.weight !== undefined) {
+      builder.weight(this.weight);
+    }
+    if (this.height !== undefined) {
+      builder.height(this.height);
+    }
+    if (this.birthDate !== undefined) {
+      builder.birthDate(this.birthDate);
+    }
+    if (this.bloodType !== undefined) {
+      builder.bloodType(this.bloodType);
+    }
+    if (this.disease !== undefined) {
+      builder.disease(this.disease);
+    }
+    if (this.medication !== undefined) {
+      builder.medication(this.medication);
+    }
+    return builder.build();
+  }
+}

--- a/src/modules/members/members.controller.ts
+++ b/src/modules/members/members.controller.ts
@@ -34,6 +34,7 @@ import { UpdateMemberDto } from './dto/update-member.dto';
 import { SearchMemberDto } from './dto/search-member.dto';
 import { GetMemberInfoDto } from './dto/get-memberInfo.dto';
 import { GetMemberDetailInfoDto } from './dto/get-memberDetail-info.dto';
+import { UpdateMemberDetailDto } from './dto/update-member-detail.dto';
 
 @ApiTags('Members')
 @UseGuards(AuthGuard('jwt'))
@@ -219,12 +220,25 @@ export class MembersController {
     return await this.favoritesService.deleteFavorite(memberId, Number(id));
   }
 
-  @Get('/info')
+  @Get('/detail')
   @ApiOperation({ summary: 'Get member info' })
   @ApiSuccessResponse(GetMemberDetailInfoDto)
   @ApiFailureResponse(ErrorStatus.INTERNAL_SERVER_ERROR)
-  async getMemberInfo(@Req() req): Promise<GetMemberDetailInfoDto> {
+  async getMemberDetail(@Req() req): Promise<GetMemberDetailInfoDto> {
     const memberId = req.user.id;
     return await this.membersService.findMemberDetailById(memberId);
+  }
+
+  @Patch('/detail')
+  @ApiOperation({ summary: 'Update member info' })
+  @ApiBody({ type: UpdateMemberDetailDto })
+  @ApiSuccessResponse()
+  @ApiFailureResponse(ErrorStatus.INTERNAL_SERVER_ERROR)
+  async updateMemberDetail(
+    @Req() req,
+    @Body() request: UpdateMemberDetailDto,
+  ): Promise<void> {
+    const member = req.user;
+    return await this.membersService.updateMemberDetailById(member, request);
   }
 }

--- a/src/modules/members/repository/membersDetail.repository.ts
+++ b/src/modules/members/repository/membersDetail.repository.ts
@@ -31,4 +31,16 @@ export class MembersDetailRepository {
       .leftJoinAndSelect('memberDetail.member', 'member')
       .getOne();
   }
+
+  async updateByMemberId(
+    memberId: number,
+    updateData: Partial<MemberDetail>,
+  ): Promise<void> {
+    await this.memberDetailRepository
+      .createQueryBuilder('memberDetail')
+      .update()
+      .set(updateData)
+      .where('memberId = :memberId', { memberId })
+      .execute();
+  }
 }

--- a/src/modules/members/services/members.service.ts
+++ b/src/modules/members/services/members.service.ts
@@ -11,6 +11,7 @@ import { NaverService } from '../../../external/naver/naver.service';
 import { SearchMemberDto } from '../dto/search-member.dto';
 import { GetMemberInfoDto } from '../dto/get-memberInfo.dto';
 import { GetMemberDetailInfoDto } from '../dto/get-memberDetail-info.dto';
+import { UpdateMemberDetailDto } from '../dto/update-member-detail.dto';
 
 @Injectable()
 export class MembersService {
@@ -163,5 +164,16 @@ export class MembersService {
       throw new ExceptionHandler(ErrorStatus.MEMBER_DETAIL_NOT_FOUND);
     }
     return GetMemberDetailInfoDto.of(memberDetail);
+  }
+
+  async updateMemberDetailById(
+    member: Member,
+    request: UpdateMemberDetailDto,
+  ): Promise<void> {
+    const memberDetail = request.toEntity(member);
+    await this.membersDetailRepository.updateByMemberId(
+      member.id,
+      memberDetail,
+    );
   }
 }

--- a/test/unit/members/members.service.spec.ts
+++ b/test/unit/members/members.service.spec.ts
@@ -13,6 +13,7 @@ import { SearchMemberDto } from '../../../src/modules/members/dto/search-member.
 import { MemberDetailBuilder } from '../../../src/modules/members/entities/builder/memberDetail.builder';
 import { GetMemberInfoDto } from '../../../src/modules/members/dto/get-memberInfo.dto';
 import { GetMemberDetailInfoDto } from '../../../src/modules/members/dto/get-memberDetail-info.dto';
+import { UpdateMemberDetailDto } from '../../../src/modules/members/dto/update-member-detail.dto';
 
 describe('MembersService', () => {
   let service: MembersService;
@@ -41,6 +42,7 @@ describe('MembersService', () => {
           useValue: {
             update: jest.fn(),
             findByMemberId: jest.fn(),
+            updateByMemberId: jest.fn(),
           },
         },
         {
@@ -247,6 +249,25 @@ describe('MembersService', () => {
         .mockResolvedValue(null);
       await expect(service.findMemberDetailById(1)).rejects.toThrow(
         new ExceptionHandler(ErrorStatus.MEMBER_DETAIL_NOT_FOUND),
+      );
+    });
+  });
+
+  describe('updateMemberDetailById', () => {
+    it('should update the member detail successfully', async () => {
+      const member = new MemberBuilder().id(1).build();
+      const request = new UpdateMemberDetailDto();
+      const memberDetail = request.toEntity(member);
+
+      jest
+        .spyOn(membersDetailRepository, 'updateByMemberId')
+        .mockResolvedValue(undefined);
+
+      await service.updateMemberDetailById(member, request);
+      expect(membersDetailRepository.updateByMemberId).toHaveBeenCalledTimes(1);
+      expect(membersDetailRepository.updateByMemberId).toHaveBeenCalledWith(
+        member.id,
+        memberDetail,
       );
     });
   });


### PR DESCRIPTION
## #️⃣Related Issue
> #139

## 📝Work Description
1. 사용자가 본인의 건강 정보를 수정할 수 있는 api 구현
<img width="574" alt="image" src="https://github.com/user-attachments/assets/6f043d83-eed7-48fb-bf2b-00790096ded8">

2. 테스트 코드 작성
<img width="677" alt="image" src="https://github.com/user-attachments/assets/503b9d95-1cf3-459b-88bf-255c68f235ec">

