### PR TITLE
:sparkles: [Feat] Implement send help request near favorite users

### DIFF
--- a/src/modules/alarm/services/notification-action.service.ts
+++ b/src/modules/alarm/services/notification-action.service.ts
@@ -30,6 +30,7 @@ export class NotificationActionService {
     [NotificationType.NEARBY_EVENT]: this.processNearbyEvent.bind(this),
     [NotificationType.FAVORITE_NEARBY_EVENT]:
       this.processFavoriteNearbyEvent.bind(this),
+    [NotificationType.HELP_REQUEST]: this.processHelpRequest.bind(this),
   };
 
   private async processFavoriteRequest(notification: Notification) {
@@ -71,6 +72,22 @@ export class NotificationActionService {
         NotificationMessage.FAVORITE_NEARBY_EVENT,
         { nickname: member.nickname },
       ),
+      url: '/members/{id}',
+    };
+  }
+
+  private async processHelpRequest(notification: Notification) {
+    const member = await this.membersRepository.findById(
+      notification.referenceId,
+    );
+    if (!member) {
+      throw new ExceptionHandler(ErrorStatus.MEMBER_NOT_FOUND);
+    }
+    return {
+      id: member.id,
+      message: formatNotificationMessage(NotificationMessage.HELP_REQUEST, {
+        nickname: member.nickname,
+      }),
       url: '/members/{id}',
     };
   }

--- a/src/modules/members/services/favorites.service.ts
+++ b/src/modules/members/services/favorites.service.ts
@@ -131,4 +131,17 @@ export class FavoritesService {
   async deleteFavorite(memberId: number, favoriteId: number): Promise<void> {
     await this.favoritesRepository.deleteById(favoriteId, memberId);
   }
+
+  async checkFavorite(
+    memberId: number,
+    favoritedMemberId: number,
+  ): Promise<void> {
+    const favorite = await this.favoritesRepository.findFavorite(
+      memberId,
+      favoritedMemberId,
+    );
+    if (!favorite) {
+      throw new ExceptionHandler(ErrorStatus.FAVORITE_NOT_FOUND);
+    }
+  }
 }

--- a/test/unit/alarm/notirication-action.service.spec.ts
+++ b/test/unit/alarm/notirication-action.service.spec.ts
@@ -124,6 +124,29 @@ describe('NotificationActionService', () => {
       );
     });
 
+    it('should return details for FAVORITE_NEARBY_EVENT successfully', async () => {
+      const member = new MemberBuilder().id(1).nickname('test').build();
+      const notification = new NotificationBuilder()
+        .id(1)
+        .type(NotificationType.HELP_REQUEST)
+        .referenceId(1)
+        .build();
+      jest.spyOn(membersRepository, 'findById').mockResolvedValue(member);
+
+      const result =
+        await notificationActionService.getActionDetails(notification);
+
+      expect(membersRepository.findById).toHaveBeenCalledWith(
+        notification.referenceId,
+      );
+      expect(result!.id).toEqual(member.id);
+      expect(result!.message).toEqual(
+        formatNotificationMessage(NotificationMessage.HELP_REQUEST, {
+          nickname: member.nickname,
+        }),
+      );
+    });
+
     it('should throw FAVORITE_NOT_FOUND if the favorite is not found', async () => {
       jest.spyOn(favoritesRepository, 'findById').mockResolvedValue(null);
       const notification = new NotificationBuilder()
@@ -154,6 +177,18 @@ describe('NotificationActionService', () => {
       const notification = new NotificationBuilder()
         .id(1)
         .type(NotificationType.FAVORITE_NEARBY_EVENT)
+        .referenceId(1)
+        .build();
+      await expect(
+        notificationActionService.getActionDetails(notification),
+      ).rejects.toThrow(new ExceptionHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    });
+
+    it('should throw MEMBER_NOT_FOUND if the member does not exist', async () => {
+      jest.spyOn(membersRepository, 'findById').mockResolvedValue(null);
+      const notification = new NotificationBuilder()
+        .id(1)
+        .type(NotificationType.HELP_REQUEST)
         .referenceId(1)
         .build();
       await expect(

--- a/test/unit/members/favorites.service.spec.ts
+++ b/test/unit/members/favorites.service.spec.ts
@@ -408,4 +408,50 @@ describe('FavoritesService', () => {
       );
     });
   });
+
+  describe('checkFavorite', () => {
+    let member: Member;
+    let favoritedMember: Member;
+    let favorite: Favorite;
+
+    beforeEach(() => {
+      member = new MemberBuilder().id(1).build();
+      favoritedMember = new MemberBuilder().id(2).build();
+      favorite = new FavoriteBuilder()
+        .id(1)
+        .member(member)
+        .favoritedMember(favoritedMember)
+        .build();
+    });
+
+    it('should do nothing if the favorite exists', async () => {
+      const memberId = 1;
+      const favoritedMemberId = 2;
+
+      jest
+        .spyOn(favoritesRepository, 'findFavorite')
+        .mockResolvedValue(favorite);
+
+      await favoritesService.checkFavorite(memberId, favoritedMemberId);
+      expect(favoritesRepository.findFavorite).toHaveBeenCalledWith(
+        memberId,
+        favoritedMemberId,
+      );
+    });
+    it('should throw FAVORITE_NOT_FOUND error if the favorite does not exist', async () => {
+      const memberId = 1;
+      const favoritedMemberId = 2;
+
+      jest.spyOn(favoritesRepository, 'findFavorite').mockResolvedValue(null);
+
+      await expect(
+        favoritesService.checkFavorite(memberId, favoritedMemberId),
+      ).rejects.toThrow(new ExceptionHandler(ErrorStatus.FAVORITE_NOT_FOUND));
+
+      expect(favoritesRepository.findFavorite).toHaveBeenCalledWith(
+        memberId,
+        favoritedMemberId,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## #️⃣Related Issue
> #153

## 📝Work Description
1. 사용자가 지인으로 등록한 사용자 대신해서 주변에서 도움을 요청할 수 있는 기능 구현
<img width="808" alt="image" src="https://github.com/user-attachments/assets/aabde8d5-261b-48be-961d-caa562f5a33a">

2. 테스트 코드 작성
<img width="384" alt="image" src="https://github.com/user-attachments/assets/0f503932-5909-4add-a44f-35a28f37c9f9">
