### PR TITLE
:hammer: [Fix] Fix get event overview api

### DIFF
--- a/src/modules/events/dto/find-event-overview.dto.ts
+++ b/src/modules/events/dto/find-event-overview.dto.ts
@@ -26,6 +26,10 @@ export class FindEventOverviewDto {
   createdAt: Date;
   @ApiProperty()
   keywords: string[];
+  @ApiProperty()
+  latitude: number;
+  @ApiProperty()
+  longitude: number;
 
   constructor(
     id: number,
@@ -37,6 +41,8 @@ export class FindEventOverviewDto {
     memberProfile: string,
     memberNickname: string,
     keywords: string[],
+    latitude: number,
+    longitude: number,
     media?: string,
     content?: string,
   ) {
@@ -51,6 +57,8 @@ export class FindEventOverviewDto {
     this.address = address;
     this.memberProfile = memberProfile;
     this.memberNickname = memberNickname;
+    this.latitude = latitude;
+    this.longitude = longitude;
   }
 
   static of(event: Event): FindEventOverviewDto {
@@ -65,6 +73,8 @@ export class FindEventOverviewDto {
       event.member.memberDetail!.profilePicture!,
       event.member.nickname,
       keywords,
+      event.latitude,
+      event.longitude,
       event.media,
       event.content,
     );


### PR DESCRIPTION
## #️⃣Related Issue
> #171

## 📝Work Description
1. 이벤트 미리보기 api에서 lat,lng 값을 반환
<img width="396" alt="image" src="https://github.com/user-attachments/assets/5f1df1e3-a9d6-4ed0-9caf-ba51ba7df5ef">

