### PR TITLE
:sparkles: [Feat] Implement delete event api

### DIFF
--- a/src/common/api/status/error.status.ts
+++ b/src/common/api/status/error.status.ts
@@ -97,6 +97,11 @@ export class ErrorStatus implements BaseCode {
     400,
     '주소를 찾을 수 없습니다.',
   );
+  static readonly EVENT_NOT_OWNER = new ErrorStatus(
+    false,
+    400,
+    '이벤트의 소유자가 아닙니다.',
+  );
 
   //S3 에러
   static readonly S3_UPLOAD_FAILURE = new ErrorStatus(
@@ -126,5 +131,11 @@ export class ErrorStatus implements BaseCode {
     false,
     400,
     'Push 메시지를 보내는데 실패했습니다',
+  );
+
+  static readonly S3_DELETE_FAILURE = new ErrorStatus(
+    false,
+    400,
+    '이미지 삭제에 실패했습니다.',
   );
 }

--- a/src/external/s3/s3.service.ts
+++ b/src/external/s3/s3.service.ts
@@ -1,4 +1,8 @@
-import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  DeleteObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { ErrorStatus } from 'src/common/api/status/error.status';
@@ -42,5 +46,19 @@ export class S3Service {
     const bucketName = this.configService.get<string>('BUCKET_NAME');
     const region = this.configService.get<string>('BUCKET_REGION');
     return `https://${bucketName}.s3.${region}.amazonaws.com/${key}`;
+  }
+
+  async delete(key: string): Promise<void> {
+    const data = {
+      Bucket: this.configService.get<string>('BUCKET_NAME'),
+      Key: key,
+    };
+
+    try {
+      const command = new DeleteObjectCommand(data);
+      await this.s3Client.send(command);
+    } catch (error) {
+      throw new ExceptionHandler(ErrorStatus.S3_DELETE_FAILURE);
+    }
   }
 }

--- a/src/modules/events/entities/comment.entity.ts
+++ b/src/modules/events/entities/comment.entity.ts
@@ -14,11 +14,11 @@ export class Comment extends DefaultEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id!: number;
 
-  @ManyToOne(() => Event)
+  @ManyToOne(() => Event, { onDelete: 'CASCADE' })
   @JoinColumn()
   event!: Event;
 
-  @ManyToOne(() => Member)
+  @ManyToOne(() => Member, { onDelete: 'CASCADE' })
   @JoinColumn()
   member!: Member;
 

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -9,6 +9,7 @@ import {
   Query,
   UseInterceptors,
   UploadedFile,
+  Delete,
 } from '@nestjs/common';
 import { EventsService } from './services/events.service';
 import { CreateEventDto } from './dto/create-event.dto';
@@ -234,5 +235,18 @@ export class EventsController {
   async getEvents(@Request() req): Promise<GetEventsDto> {
     const member = req.user;
     return await this.eventsService.getEvents(member);
+  }
+
+  @Delete(':id(\\d+)')
+  @ApiOperation({ summary: '이벤트 삭제' })
+  @ApiSuccessResponse()
+  @ApiFailureResponse(
+    ErrorStatus.EVENT_NOT_FOUND,
+    ErrorStatus.INTERNAL_SERVER_ERROR,
+    ErrorStatus.S3_DELETE_FAILURE,
+  )
+  async deleteEvent(@Param('id') id: string, @Request() req) {
+    const member = req.user;
+    await this.eventsService.deleteEvent(Number(id), member);
   }
 }

--- a/src/modules/events/repository/events.repository.ts
+++ b/src/modules/events/repository/events.repository.ts
@@ -104,4 +104,8 @@ export class EventsRepository {
       .where('event.memberId = :memberId', { memberId })
       .getMany();
   }
+
+  async delete(event: Event): Promise<void> {
+    await this.eventRepository.delete({ id: event.id });
+  }
 }

--- a/src/modules/events/services/events.service.ts
+++ b/src/modules/events/services/events.service.ts
@@ -167,6 +167,20 @@ export class EventsService {
     return GetEventsDto.of(events);
   }
 
+  async deleteEvent(eventId: number, member: Member) {
+    const event = await this.eventsRepository.findById(eventId);
+    if (!event) {
+      throw new ExceptionHandler(ErrorStatus.EVENT_NOT_FOUND);
+    }
+    if (event.member.id !== member.id) {
+      throw new ExceptionHandler(ErrorStatus.EVENT_NOT_OWNER);
+    }
+    if (event.media) {
+      await this.s3Service.delete(event.media);
+    }
+    await this.eventsRepository.delete(event);
+  }
+
   private isValidLocation(lat: number, lng: number) {
     if (
       lat === undefined ||


### PR DESCRIPTION
## #️⃣Related Issue
> #177

## 📝Work Description
1. 이벤트 삭제 api 구현 -> 좋아요와 댓글, S3 이미지 삭제
<img width="1107" alt="image" src="https://github.com/user-attachments/assets/b990747c-f3ca-4198-aa5f-38ad39f1d830">


2. 테스트 코드 작성
<img width="585" alt="image" src="https://github.com/user-attachments/assets/cdabbc89-147a-474d-a457-4bb4b2c65be9">

