### PR TITLE
:sparkles: [Feat] Implement delete comment api

### DIFF
--- a/src/common/api/status/error.status.ts
+++ b/src/common/api/status/error.status.ts
@@ -138,4 +138,16 @@ export class ErrorStatus implements BaseCode {
     400,
     '이미지 삭제에 실패했습니다.',
   );
+
+  static readonly COMMENT_NOT_FOUND = new ErrorStatus(
+    false,
+    400,
+    '해당 댓글이 존재하지 않습니다.',
+  );
+
+  static readonly COMMENT_NOT_MATCH = new ErrorStatus(
+    false,
+    400,
+    '댓글 작성자가 아닙니다.',
+  );
 }

--- a/src/modules/events/entities/event.entity.ts
+++ b/src/modules/events/entities/event.entity.ts
@@ -62,6 +62,10 @@ export class Event extends DefaultEntity {
     this.commentsCount++;
   }
 
+  subCommentCount(): void {
+    this.commentsCount = this.commentsCount > 0 ? this.commentsCount - 1 : 0;
+  }
+
   addLikeCount() {
     this.likesCount++;
   }

--- a/src/modules/events/events.controller.ts
+++ b/src/modules/events/events.controller.ts
@@ -237,6 +237,21 @@ export class EventsController {
     return await this.eventsService.getEvents(member);
   }
 
+  @Delete('/comment/:commentId')
+  @ApiOperation({ summary: '댓글 삭제' })
+  @ApiSuccessResponse()
+  @ApiFailureResponse(
+    ErrorStatus.MEMBER_NOT_FOUND,
+    ErrorStatus.COMMENT_NOT_FOUND,
+    ErrorStatus.COMMENT_NOT_MATCH,
+    ErrorStatus.EVENT_NOT_FOUND,
+    ErrorStatus.INTERNAL_SERVER_ERROR,
+  )
+  async deleteComment(@Param('commentId') commentId: string, @Request() req) {
+    const member = req.user;
+    await this.commentService.deleteComment(Number(commentId), member);
+  }
+
   @Delete(':id(\\d+)')
   @ApiOperation({ summary: '이벤트 삭제' })
   @ApiSuccessResponse()

--- a/src/modules/events/repository/comment.repository.ts
+++ b/src/modules/events/repository/comment.repository.ts
@@ -12,4 +12,17 @@ export class CommentRepository {
   async create(comment: Comment): Promise<Comment> {
     return this.commentRepository.save(comment);
   }
+
+  async findOne(commentId: number): Promise<Comment | null> {
+    return this.commentRepository
+      .createQueryBuilder('comment')
+      .where('comment.id=:commentId', { commentId })
+      .leftJoinAndSelect('comment.member', 'member')
+      .leftJoinAndSelect('comment.event', 'event')
+      .getOne();
+  }
+
+  async delete(commentId: number): Promise<void> {
+    await this.commentRepository.delete(commentId);
+  }
 }


### PR DESCRIPTION
## #️⃣Related Issue
> #179

## 📝Work Description
1. 댓글 삭제 api 구현 -> 댓글 삭제 시 이벤트의 댓글 개수 감소
<img width="860" alt="image" src="https://github.com/user-attachments/assets/ef12b72b-ba5b-43a3-aaf9-63c01d15c3ad">


2. 테스트 코드 작성
<img width="662" alt="image" src="https://github.com/user-attachments/assets/75d0ad0c-dafa-4737-a813-c559a7d8d1c0">

